### PR TITLE
Func separation example

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@
 import SimpleLightbox from 'simplelightbox';
 import 'simplelightbox/dist/simple-lightbox.min.css';
 import Notiflix from 'notiflix';
-import axios from 'axios';
 
 import { fadeEffect } from './js/preloader';
+import { fetchImages } from './js/fetchImages';
 
 // HTML elements
 
@@ -16,9 +16,6 @@ const gallery = document.querySelector('.gallery');
 const loadBtn = document.querySelector('.load-more');
 
 // Needed to query the Pixabay API
-
-const baseURL = 'https://pixabay.com/api/';
-const key = '28143013-44919de38ad9e5402793063fb';
 let perPage = 40;
 let page = 0;
 let name = searchQuery.value;
@@ -27,19 +24,6 @@ let name = searchQuery.value;
 
 loadBtn.style.display = 'none';
 closeBtn.style.display = 'none';
-
-// Fetch images from Pixabay API using Axios
-
-async function fetchImages(name, page) {
-  try {
-    const response = await axios.get(
-      `${baseURL}?key=${key}&q=${name}&image_type=photo&orientation=horizontal&safesearch=true&page=${page}&per_page=${perPage}`
-    );
-    return response.data;
-  } catch (error) {
-    console.log('ERROR: ' + error);
-  }
-}
 
 // Handling the "submit" button event
 
@@ -51,7 +35,7 @@ async function eventHandler(e) {
   page = 1;
   name = searchQuery.value;
 
-  fetchImages(name, page)
+  fetchImages(name, page, perPage)
     .then(name => {
       let totalPages = name.totalHits / perPage;
 
@@ -143,7 +127,7 @@ loadBtn.addEventListener(
   () => {
     name = searchQuery.value;
     page += 1;
-    fetchImages(name, page).then(name => {
+    fetchImages(name, page, perPage).then(name => {
       let totalPages = name.totalHits / perPage;
       renderGallery(name);
       new SimpleLightbox('.gallery a');

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,7 @@ import 'simplelightbox/dist/simple-lightbox.min.css';
 import Notiflix from 'notiflix';
 import axios from 'axios';
 
-import { preloader, fadeEffect } from './js/preloader';
-
+import { fadeEffect } from './js/preloader';
 
 // HTML elements
 

--- a/src/js/fetchImages.js
+++ b/src/js/fetchImages.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+// Fetch images from Pixabay API using Axios
+
+async function fetchImages(name, page, perPage) {
+  const baseURL = 'https://pixabay.com/api/';
+  const key = '28143013-44919de38ad9e5402793063fb';
+
+  try {
+    const response = await axios.get(
+      `${baseURL}?key=${key}&q=${name}&image_type=photo&orientation=horizontal&safesearch=true&page=${page}&per_page=${perPage}`
+    );
+    return response.data;
+  } catch (error) {
+    console.log('ERROR: ' + error);
+  }
+}
+
+export { fetchImages };

--- a/src/js/preloader.js
+++ b/src/js/preloader.js
@@ -1,13 +1,17 @@
-export const preloader = document.querySelector('.preloader');
+const preloader = document.querySelector('.preloader');
 
-export const fadeEffect = setInterval(() => {
-  if (!preloader.style.opacity) {
-    preloader.style.opacity = 1;
-  }
-  if (preloader.style.opacity > 0) {
-    preloader.style.opacity -= 0.1;
-  } else {
-    clearInterval(fadeEffect);
-    preloader.remove();
-  }
-}, 200);
+const fadeEffect = () => {
+  setInterval(() => {
+    if (!preloader.style.opacity) {
+      preloader.style.opacity = 1;
+    }
+    if (preloader.style.opacity > 0) {
+      preloader.style.opacity -= 0.1;
+    } else {
+      clearInterval(fadeEffect);
+      preloader.remove();
+    }
+  }, 200);
+};
+
+export { fadeEffect };


### PR DESCRIPTION
Hej Pawel,
Zobacz sobie zmiany, jakie wprowadziłam. Podsumowując:

1. preloader działał, ale nie tak jak chciałeś - ten kod odpalał się w momencie jak był import w index.js, bo `setInterval` w `fadeEffect` był wywoływany od razu i do `fadeEffect` była przypisywana wartość zwracana przez `setIterval` - wsadziłam to w funkcję anonimową, która powoduje, że `fadeEffect` jest funkcją, która wywołuje setInterval i można ją przypisać jako callback do eventListenera, jak zrobiłeś
2. zmieniłam export na [export list](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) i wyexportowałam tylko co potrzebne (element html nie jest nam potrzebny poza tym plikiem)
3. utworzyłam plik fadeEffect.js i tam wyeksportowałam funkcję `fadeEffect` (razem ze zmiennymi baseURL i key). Funkcja korzysta ze zmiennej globalnej perPage, która teraz `fadeEffect` przyjmuje jako argument (i to samo możesz zrobić z pozostałymi funkcjami i zmiennymi).